### PR TITLE
Fix php doc and make overwrite message more explicit

### DIFF
--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -22,7 +22,7 @@ abstract class AbstractCommand extends Command
     protected function copyFile(InputInterface $input, OutputInterface $output, $source, $destination)
     {
         $fs = new Filesystem();
-        if ($fs->exists($destination) && !$this->askForOverwrite($input, $output)) {
+        if ($fs->exists($destination) && !$this->askForOverwrite($input, $output, $source, $destination)) {
             return;
         }
 
@@ -44,23 +44,34 @@ abstract class AbstractCommand extends Command
      * Ask for overwrite
      *
      * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param string $source
+     * @param string $destination
      * @param string $message
-     * @param mixed $default
+     * @param bool $default
      *
      * @return bool
      */
     protected function askForOverwrite(
         InputInterface $input,
         OutputInterface $output,
-        $message = 'Overwrite?',
+        $source,
+        $destination,
+        $message = null,
         $default = false
     ) {
-        $helper = $this->getHelper('question');
-        $overwriteQuestion = new ConfirmationQuestion('Overwrite?', $default);
-        if (!$helper->ask($input, $output, $overwriteQuestion)) {
-            return false;
+        if (null === $message) {
+            $availableOptionsText = $default ? '[Y/n]' : '[y/N]';
+            $message = sprintf(
+                '%s already exists in destination folder %s. Overwrite? %s ',
+                pathinfo($source, PATHINFO_BASENAME),
+                pathinfo(realpath($destination), PATHINFO_DIRNAME),
+                $availableOptionsText
+            );
         }
+        $helper = $this->getHelper('question');
+        $overwriteQuestion = new ConfirmationQuestion($message, $default);
 
-        return true;
+        return $helper->ask($input, $output, $overwriteQuestion);
     }
 }


### PR DESCRIPTION
```
$ vendor/bin/prestashop-coding-standards cs-fixer:init
php_cs.dist already exists in destination folder /home/thomas/Documents/github/ps_checkpayment. Overwrite? [y/N] y
File "php_cs.dist" copied to "./.php_cs.dist"
prettyci.composer.json already exists in destination folder /home/thomas/Documents/github/ps_checkpayment. Overwrite? [y/N] y
File "prettyci.composer.json" copied to "./.prettyci.composer.json"
```